### PR TITLE
signed counter type for >=0 loop

### DIFF
--- a/src/ofxSyncedParams.cpp
+++ b/src/ofxSyncedParams.cpp
@@ -198,7 +198,7 @@ void ofxSyncedParams::parameterChanged( ofAbstractParameter & parameter ){
 	vector<string> treeHierarchy = parameter.getGroupHierarchyNames();
 	list<string> hierarchy;
 	//walk from first parent [size()-2] to rootGroup [-2 because paramName is also part of the hierarchy]
-	for(size_t i=treeHierarchy.size()-2;i>=0; --i){ //
+	for(int i=treeHierarchy.size()-2;i>=0; --i){ //
 		string & groupName = treeHierarchy[i];
 		hierarchy.push_front(groupName);
 		if(groupName == rootGroup->getName()){


### PR DESCRIPTION
size_t is an unsigned type. This was causing crashes with both examples on osx.
